### PR TITLE
remove deprecated curl_close

### DIFF
--- a/bayshop.3m.php
+++ b/bayshop.3m.php
@@ -148,7 +148,6 @@ function loadPage(string $path): string
     ]);
 
     $response = curl_exec($ch);
-    curl_close($ch);
 
     return $response;
 }


### PR DESCRIPTION
<img width="959" height="311" alt="bayshop-tracker" src="https://github.com/user-attachments/assets/4629db68-26c0-4006-9c53-e7f2de01c756" />
